### PR TITLE
remove `tomli` from `docs` build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ docs = [
     'sphinx-astropy',
     'sphinx-rtd-theme',
     'stsci-rtd-theme',
-    'tomli; python_version <"3.11"',
 ]
 test = [
     'psutil',


### PR DESCRIPTION
`tomli` is not used here (at least not that I can find)